### PR TITLE
Fix issue that breaks latest SendGrid API rules

### DIFF
--- a/lib/Stampie/Mailer/SendGrid.php
+++ b/lib/Stampie/Mailer/SendGrid.php
@@ -129,12 +129,15 @@ class SendGrid extends Mailer
             'html'     => $message->getHtml(),
             'bcc'      => $bccEmails,
             'replyto'  => $message->getReplyTo(),
-            'headers'  => json_encode($message->getHeaders()),
             'content'  => $inline,
         );
 
         if ($smtpApi) {
             $parameters['x-smtpapi'] = json_encode(array_filter($smtpApi));
+        }
+
+        if ($message->getHeaders()) {
+            $parameters['headers'] = json_encode($message->getHeaders());
         }
 
         return http_build_query(array_filter($parameters));


### PR DESCRIPTION
We noticed that sendgrid emails suddenly stopped working and after some investigations, it turned out that when the headers array is empty, the sendgrid API return an invalid json error. To workaround that, only include headers in the parameters when there are actual header values.

@henrikbjorn please review and merge if this makes sense.
